### PR TITLE
Enable add counters into energy configuration in HA

### DIFF
--- a/custom_components/sauresha/sensor.py
+++ b/custom_components/sauresha/sensor.py
@@ -222,13 +222,13 @@ class SauresSensor(Entity):
             if self.isStart:
                 if meter.type_number == 1 or meter.type_number == 2 or meter.type_number == 3:
                     self._attributes.update({
-                        'unit_of_measurement': 'м³'})
+                        'unit_of_measurement': 'm³'})
                 elif meter.type_number == 5:
                     self._attributes.update({
                         'unit_of_measurement': '°C'})
                 elif meter.type_number == 8:
                     self._attributes.update({
-                        'unit_of_measurement': 'кВт·ч'})
+                        'unit_of_measurement': 'kWh'})
 
                 self.isStart = False
 

--- a/custom_components/sauresha/sensor.py
+++ b/custom_components/sauresha/sensor.py
@@ -222,7 +222,9 @@ class SauresSensor(Entity):
             if self.isStart:
                 if meter.type_number == 1 or meter.type_number == 2:
                     self._attributes.update({
-                        'unit_of_measurement': 'm³'})
+                        'unit_of_measurement': 'm³',
+                        'device_class': 'water',
+                        'state_class': 'total_increasing'})
                 if meter.type_number == 3:
                     self._attributes.update({
                         'unit_of_measurement': 'm³',

--- a/custom_components/sauresha/sensor.py
+++ b/custom_components/sauresha/sensor.py
@@ -226,14 +226,16 @@ class SauresSensor(Entity):
                 if meter.type_number == 3:
                     self._attributes.update({
                         'unit_of_measurement': 'm³',
-                        'device_class': 'gas'})
+                        'device_class': 'gas',
+                        'state_class': 'total_increasing'})
                 elif meter.type_number == 5:
                     self._attributes.update({
                         'unit_of_measurement': '°C'})
                 elif meter.type_number == 8:
                     self._attributes.update({
                         'unit_of_measurement': 'kWh',
-                        'device_class': 'energy'})
+                        'device_class': 'energy',
+                        'state_class': 'total_increasing'})
 
                 self.isStart = False
 

--- a/custom_components/sauresha/sensor.py
+++ b/custom_components/sauresha/sensor.py
@@ -220,15 +220,20 @@ class SauresSensor(Entity):
                     'approve_dt': meter.approve_dt,
                 })
             if self.isStart:
-                if meter.type_number == 1 or meter.type_number == 2 or meter.type_number == 3:
+                if meter.type_number == 1 or meter.type_number == 2:
                     self._attributes.update({
                         'unit_of_measurement': 'm³'})
+                if meter.type_number == 3:
+                    self._attributes.update({
+                        'unit_of_measurement': 'm³',
+                        'device_class': 'gas'})
                 elif meter.type_number == 5:
                     self._attributes.update({
                         'unit_of_measurement': '°C'})
                 elif meter.type_number == 8:
                     self._attributes.update({
-                        'unit_of_measurement': 'kWh'})
+                        'unit_of_measurement': 'kWh',
+                        'device_class': 'energy'})
 
                 self.isStart = False
 


### PR DESCRIPTION
I try to add my saures gas counter from sauresha to HA energy config.
But button "Add gas source" not showing my sauresha gas sensor. 
By my opinion its not working because unit_of_measurement is `м3 `, but need `m3`. But its not enough. 